### PR TITLE
Handle Invalid Characters in Source Tables

### DIFF
--- a/databricks.yml
+++ b/databricks.yml
@@ -25,14 +25,14 @@ targets:
     mode: development
     default: true
     workspace:
-      host: https://company-dev.cloud.databricks.com/
+      host: https://e2-demo-field-eng.cloud.databricks.com/
     variables:
       cluster_id:
         lookup:
           cluster: "Field Eng Shared UC LTS Cluster"
       warehouse_id:
         lookup:
-          warehouse: "Shared Endpoint"
+          warehouse: "Shared Unity Catalog Serverless"
       concurrency: 16
 
   prod:

--- a/databricks.yml
+++ b/databricks.yml
@@ -25,14 +25,14 @@ targets:
     mode: development
     default: true
     workspace:
-      host: https://e2-demo-field-eng.cloud.databricks.com/
+      host: https://company-dev.cloud.databricks.com/
     variables:
       cluster_id:
         lookup:
           cluster: "Field Eng Shared UC LTS Cluster"
       warehouse_id:
         lookup:
-          warehouse: "Shared Unity Catalog Serverless"
+          warehouse: "Serverless Warehouse"
       concurrency: 16
 
   prod:

--- a/resources/lakefed_ingest_copy.yml
+++ b/resources/lakefed_ingest_copy.yml
@@ -9,9 +9,21 @@ resources:
             file:
               path: ../src/lakefed_ingest/get_task.sql
             warehouse_id: ${var.warehouse_id}
-        - task_key: create_sink_table
+        - task_key: get_src_tbl_metadata
           depends_on:
             - task_key: get_task
+          sql_task:
+            file:
+              path: ../src/lakefed_ingest/get_src_tbl_metadata.sql
+            parameters:
+              src_catalog: "{{tasks.get_task.output.first_row.src_catalog}}"
+              src_schema: "{{tasks.get_task.output.first_row.src_schema}}"
+              src_table: "{{tasks.get_task.output.first_row.src_table}}"
+              select_list: "{{tasks.get_task.output.first_row.select_list}}"
+            warehouse_id: ${var.warehouse_id}
+        - task_key: create_sink_table
+          depends_on:
+            - task_key: get_src_tbl_metadata
           notebook_task:
             notebook_path: ../src/lakefed_ingest/create_sink_table.ipynb
             base_parameters:
@@ -24,6 +36,7 @@ resources:
               tgt_table: "{{tasks.get_task.output.first_row.sink_table}}"
               enable_iceberg_reads: "{{tasks.get_task.output.first_row.enable_iceberg_reads}}"
               sink_cluster_cols: "{{tasks.get_task.output.first_row.sink_cluster_cols}}"
+              src_tbl_metadata: "{{tasks.get_src_tbl_metadata.output.first_row.json_metadata}}"
             source: WORKSPACE
             warehouse_id: ${var.warehouse_id}
         - task_key: if_incremental

--- a/resources/lakefed_ingest_copy.yml
+++ b/resources/lakefed_ingest_copy.yml
@@ -34,6 +34,7 @@ resources:
               tgt_catalog: "{{tasks.get_task.output.first_row.sink_catalog}}"
               tgt_schema: "{{tasks.get_task.output.first_row.sink_schema}}"
               tgt_table: "{{tasks.get_task.output.first_row.sink_table}}"
+              load_partitioned: "{{tasks.get_task.output.first_row.load_partitioned}}"
               enable_iceberg_reads: "{{tasks.get_task.output.first_row.enable_iceberg_reads}}"
               sink_cluster_cols: "{{tasks.get_task.output.first_row.sink_cluster_cols}}"
               src_tbl_metadata: "{{tasks.get_src_tbl_metadata.output.first_row.json_metadata}}"

--- a/resources/lakefed_ingest_copy_partitioned_lvl1.yml
+++ b/resources/lakefed_ingest_copy_partitioned_lvl1.yml
@@ -74,6 +74,7 @@ resources:
                   src_schema: "{{tasks.get_task.output.first_row.src_schema}}"
                   src_catalog: "{{tasks.get_task.output.first_row.src_catalog}}"
                   src_table: "{{tasks.get_task.output.first_row.src_table}}"
+                  select_list: "{{tasks.get_task.output.first_row.select_list}}"
                   tgt_catalog: "{{tasks.get_task.output.first_row.sink_catalog}}"
                   tgt_schema: "{{tasks.get_task.output.first_row.sink_schema}}"
                   tgt_table: "{{tasks.get_task.output.first_row.sink_table}}"

--- a/resources/lakefed_ingest_copy_partitioned_lvl1.yml
+++ b/resources/lakefed_ingest_copy_partitioned_lvl1.yml
@@ -35,6 +35,7 @@ resources:
               tgt_catalog: "{{tasks.get_task.output.first_row.sink_catalog}}"
               tgt_schema: "{{tasks.get_task.output.first_row.sink_schema}}"
               tgt_table: "{{tasks.get_task.output.first_row.sink_table}}"
+              load_partitioned: "{{tasks.get_task.output.first_row.load_partitioned}}"
               enable_iceberg_reads: "{{tasks.get_task.output.first_row.enable_iceberg_reads}}"
               sink_cluster_cols: "{{tasks.get_task.output.first_row.sink_cluster_cols}}"
               src_tbl_metadata: "{{tasks.get_src_tbl_metadata.output.first_row.json_metadata}}"

--- a/resources/lakefed_ingest_copy_partitioned_lvl1.yml
+++ b/resources/lakefed_ingest_copy_partitioned_lvl1.yml
@@ -10,9 +10,21 @@ resources:
             file:
               path: ../src/lakefed_ingest/get_task.sql
             warehouse_id: ${var.warehouse_id}
-        - task_key: create_sink_table
+        - task_key: get_src_tbl_metadata
           depends_on:
             - task_key: get_task
+          sql_task:
+            file:
+              path: ../src/lakefed_ingest/get_src_tbl_metadata.sql
+            parameters:
+              src_catalog: "{{tasks.get_task.output.first_row.src_catalog}}"
+              src_schema: "{{tasks.get_task.output.first_row.src_schema}}"
+              src_table: "{{tasks.get_task.output.first_row.src_table}}"
+              select_list: "{{tasks.get_task.output.first_row.select_list}}"
+            warehouse_id: ${var.warehouse_id}
+        - task_key: create_sink_table
+          depends_on:
+            - task_key: get_src_tbl_metadata
           notebook_task:
             notebook_path: ../src/lakefed_ingest/create_sink_table.ipynb
             base_parameters:
@@ -25,6 +37,7 @@ resources:
               tgt_table: "{{tasks.get_task.output.first_row.sink_table}}"
               enable_iceberg_reads: "{{tasks.get_task.output.first_row.enable_iceberg_reads}}"
               sink_cluster_cols: "{{tasks.get_task.output.first_row.sink_cluster_cols}}"
+              src_tbl_metadata: "{{tasks.get_src_tbl_metadata.output.first_row.json_metadata}}"
             source: WORKSPACE
             warehouse_id: ${var.warehouse_id}
         - task_key: generate_partitions

--- a/resources/lakefed_ingest_copy_partitioned_lvl2.yml
+++ b/resources/lakefed_ingest_copy_partitioned_lvl2.yml
@@ -49,3 +49,5 @@ resources:
           default: ""
         - name: src_table
           default: ""
+        - name: select_list
+          default: "*"

--- a/src/lakefed_ingest/copy_data_incremental.ipynb
+++ b/src/lakefed_ingest/copy_data_incremental.ipynb
@@ -24,7 +24,7 @@
     "  -- Build query string\n",
     "  set qry_str = \n",
     "    \"create or replace temporary view vw_src as \"\n",
-    "    \"select \" || :select_list || \" from \" || :src_catalog || '.' || :src_schema || '.' || :src_table || \" with(fetchSize = 100000) \";\n",
+    "    \"select \" || :select_list || \" from \" || :src_catalog || '.' || :src_schema || '.' || :src_table || \" with(fetchSize = 200000) \";\n",
     "  \n",
     "  -- Add where clause\n",
     "  if :watermark_col_type = 'timestamp' then\n",
@@ -133,21 +133,21 @@
       "label": null,
       "name": "primary_key",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "primary_key",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "select_list": {
@@ -159,21 +159,21 @@
       "label": null,
       "name": "select_list",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "select_list",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "sink_catalog": {
@@ -185,21 +185,21 @@
       "label": null,
       "name": "sink_catalog",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "sink_catalog",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "sink_schema": {
@@ -211,21 +211,21 @@
       "label": null,
       "name": "sink_schema",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "sink_schema",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "sink_table": {
@@ -237,21 +237,21 @@
       "label": null,
       "name": "sink_table",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "sink_table",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "src_catalog": {
@@ -263,21 +263,21 @@
       "label": null,
       "name": "src_catalog",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "src_catalog",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "src_schema": {
@@ -289,21 +289,21 @@
       "label": null,
       "name": "src_schema",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "src_schema",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "src_table": {
@@ -315,21 +315,21 @@
       "label": null,
       "name": "src_table",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "src_table",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "watermark_col_end_value": {
@@ -341,21 +341,21 @@
       "label": null,
       "name": "watermark_col_end_value",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "watermark_col_end_value",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "watermark_col_name": {
@@ -367,21 +367,21 @@
       "label": null,
       "name": "watermark_col_name",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "watermark_col_name",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "watermark_col_start_value": {
@@ -393,21 +393,21 @@
       "label": null,
       "name": "watermark_col_start_value",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "watermark_col_start_value",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "watermark_col_type": {
@@ -419,21 +419,21 @@
       "label": null,
       "name": "watermark_col_type",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "watermark_col_type",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     }
    }

--- a/src/lakefed_ingest/copy_data_partitioned.ipynb
+++ b/src/lakefed_ingest/copy_data_partitioned.ipynb
@@ -31,7 +31,7 @@
     "-- Build query string using parameters and where_clause variable\n",
     "set var qry_str = \n",
     "    'insert into ' || :tgt_catalog || '.' || :tgt_schema || '.' || :tgt_table || ' ' ||\n",
-    "    'select * from ' || :src_catalog || '.' || :src_schema || '.' || :src_table || ' ' ||\n",
+    "    'select ' || :select_list || ' from ' || :src_catalog || '.' || :src_schema || '.' || :src_table || ' ' ||\n",
     "    'with(fetchSize = 200000) where ' || where_clause;\n",
     "\n",
     "execute immediate qry_str;"

--- a/src/lakefed_ingest/create_sink_table.ipynb
+++ b/src/lakefed_ingest/create_sink_table.ipynb
@@ -39,13 +39,17 @@
     "  from (\n",
     "    select\n",
     "      col.name       as col_name,\n",
-    "      col.type.name  as col_type\n",
+    "      case\n",
+    "        when col.type.name in ('char', 'varchar') then concat(col.type.name, '(', col.type.length, ')') \n",
+    "        when col.type.name = 'decimal' then concat(col.type.name, '(', col.type.precision, ',', col.type.scale, ')')\n",
+    "        else col.type.name\n",
+    "      end as col_type\n",
     "    from (\n",
     "      select\n",
     "        explode(\n",
     "          from_json(\n",
     "            json_str,\n",
-    "            'struct<columns: array<struct<name: string, type: struct<name: string>>>>'\n",
+    "            'struct<columns: array<struct<name: string, type: struct<length: bigint, name: string, precision: bigint, scale: bigint>>>>'\n",
     "          ).columns\n",
     "        ) as col\n",
     "      from (values (:src_tbl_metadata)) as t(json_str)\n",
@@ -189,21 +193,21 @@
       "label": null,
       "name": "enable_iceberg_reads",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "enable_iceberg_reads",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "load_partitioned": {
@@ -215,21 +219,21 @@
       "label": null,
       "name": "load_partitioned",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "load_partitioned",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "select_list": {
@@ -241,21 +245,21 @@
       "label": "",
       "name": "select_list",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "*",
       "label": "",
       "name": "select_list",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "sink_cluster_cols": {
@@ -267,21 +271,21 @@
       "label": null,
       "name": "sink_cluster_cols",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "sink_cluster_cols",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "src_catalog": {
@@ -293,21 +297,21 @@
       "label": "",
       "name": "src_catalog",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "src_catalog",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "src_schema": {
@@ -319,21 +323,21 @@
       "label": "",
       "name": "src_schema",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "src_schema",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "src_table": {
@@ -345,21 +349,21 @@
       "label": "",
       "name": "src_table",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "src_table",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "tgt_catalog": {
@@ -371,21 +375,21 @@
       "label": "",
       "name": "tgt_catalog",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "tgt_catalog",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "tgt_schema": {
@@ -397,21 +401,21 @@
       "label": "",
       "name": "tgt_schema",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "tgt_schema",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "tgt_table": {
@@ -423,21 +427,21 @@
       "label": "",
       "name": "tgt_table",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "tgt_table",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     }
    }

--- a/src/lakefed_ingest/create_sink_table.ipynb
+++ b/src/lakefed_ingest/create_sink_table.ipynb
@@ -18,18 +18,46 @@
    },
    "outputs": [],
    "source": [
+    "-- create sink table using schema inferred from source table\n",
+    "-- column mapping is enabled to accomodate characters that are not allowed by parquet\n",
+    "-- https://docs.databricks.com/aws/en/delta/column-mapping\n",
+    "\n",
     "declare or replace qry_str string;\n",
+    "declare or replace col_list string;\n",
     "\n",
     "create catalog if not exists identifier(:tgt_catalog);\n",
     "use catalog identifier(:tgt_catalog);\n",
     "create schema if not exists identifier(:tgt_schema);\n",
     "use schema identifier(:tgt_schema);\n",
     "\n",
-    "-- Create sink table using schema inferred from foreign table\n",
+    "set var col_list = (\n",
+    "  select\n",
+    "    concat_ws(\n",
+    "      ', ',\n",
+    "      collect_list(concat('`', col_name, '`', ' ', col_type))\n",
+    "    ) as column_list\n",
+    "  from (\n",
+    "    select\n",
+    "      col.name       as col_name,\n",
+    "      col.type.name  as col_type\n",
+    "    from (\n",
+    "      select\n",
+    "        explode(\n",
+    "          from_json(\n",
+    "            json_str,\n",
+    "            'struct<columns: array<struct<name: string, type: struct<name: string>>>>'\n",
+    "          ).columns\n",
+    "        ) as col\n",
+    "      from (values (:src_tbl_metadata)) as t(json_str)\n",
+    "    )\n",
+    "  )\n",
+    ");\n",
+    "\n",
     "set var qry_str = \n",
-    "  \"create table if not exists \" || :tgt_table || \" as \"\n",
-    "  \"select \" || :select_list || \" from \" || :src_catalog || '.' || :src_schema || '.' || :src_table || \" \"  \n",
-    "  \"where 1 = 0\";\n",
+    "  'create table if not exists ' || :tgt_table || ' (' || col_list || ')'\n",
+    "  'tblproperties('\n",
+    "    '\\'delta.columnMapping.mode\\' = \\'name\\''\n",
+    "  ')';\n",
     "\n",
     "execute immediate qry_str;"
    ]
@@ -131,21 +159,21 @@
       "label": null,
       "name": "enable_iceberg_reads",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "enable_iceberg_reads",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "select_list": {
@@ -157,21 +185,21 @@
       "label": "",
       "name": "select_list",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "*",
       "label": "",
       "name": "select_list",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "sink_cluster_cols": {
@@ -183,21 +211,21 @@
       "label": null,
       "name": "sink_cluster_cols",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "sink_cluster_cols",
       "options": {
-       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "src_catalog": {
@@ -209,21 +237,21 @@
       "label": "",
       "name": "src_catalog",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "src_catalog",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "src_schema": {
@@ -235,21 +263,21 @@
       "label": "",
       "name": "src_schema",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "src_schema",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "src_table": {
@@ -261,21 +289,21 @@
       "label": "",
       "name": "src_table",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "src_table",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "tgt_catalog": {
@@ -287,21 +315,21 @@
       "label": "",
       "name": "tgt_catalog",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "tgt_catalog",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "tgt_schema": {
@@ -313,21 +341,21 @@
       "label": "",
       "name": "tgt_schema",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "tgt_schema",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     },
     "tgt_table": {
@@ -339,21 +367,21 @@
       "label": "",
       "name": "tgt_table",
       "options": {
-       "widgetDisplayType": "Text",
-       "validationRegex": null
+       "validationRegex": null,
+       "widgetDisplayType": "Text"
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
-      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "tgt_table",
       "options": {
-       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null
-      }
+       "validationRegex": null,
+       "widgetType": "text"
+      },
+      "widgetType": "text"
      }
     }
    }

--- a/src/lakefed_ingest/create_sink_table.ipynb
+++ b/src/lakefed_ingest/create_sink_table.ipynb
@@ -133,6 +133,36 @@
     "  end if;\n",
     "end"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 0,
+   "metadata": {
+    "application/vnd.databricks.v1+cell": {
+     "cellMetadata": {},
+     "inputWidgets": {},
+     "nuid": "25cfa242-4325-48ea-a824-483010b4741d",
+     "showTitle": false,
+     "tableResultSettingsMap": {},
+     "title": ""
+    }
+   },
+   "outputs": [],
+   "source": [
+    "-- Truncate target table if performing partitioned copy\n",
+    "-- Partitioned copy is used for full loads, so truncation is needed to avoid duplicates in the target\n",
+    "begin\n",
+    "  declare qry_str string;\n",
+    "  declare load_partitioned boolean;\n",
+    "  set load_partitioned = cast(:load_partitioned as boolean);\n",
+    "\n",
+    "  if load_partitioned is true then\n",
+    "    set qry_str =\n",
+    "      'truncate table ' || :tgt_catalog || '.' || :tgt_schema || '.' || :tgt_table;\n",
+    "    execute immediate qry_str;\n",
+    "  end if;\n",
+    "end"
+   ]
   }
  ],
  "metadata": {
@@ -159,21 +189,47 @@
       "label": null,
       "name": "enable_iceberg_reads",
       "options": {
-       "validationRegex": null,
-       "widgetDisplayType": "Text"
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
+      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "enable_iceberg_reads",
       "options": {
+       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null,
-       "widgetType": "text"
+       "validationRegex": null
+      }
+     }
+    },
+    "load_partitioned": {
+     "currentValue": "",
+     "nuid": "e915617f-8c59-4229-be4d-8c8975013206",
+     "typedWidgetInfo": {
+      "autoCreated": true,
+      "defaultValue": "",
+      "label": null,
+      "name": "load_partitioned",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
-      "widgetType": "text"
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": null,
+      "name": "load_partitioned",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": true,
+       "validationRegex": null
+      }
      }
     },
     "select_list": {
@@ -185,21 +241,21 @@
       "label": "",
       "name": "select_list",
       "options": {
-       "validationRegex": null,
-       "widgetDisplayType": "Text"
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
+      "widgetType": "text",
       "defaultValue": "*",
       "label": "",
       "name": "select_list",
       "options": {
+       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null,
-       "widgetType": "text"
-      },
-      "widgetType": "text"
+       "validationRegex": null
+      }
      }
     },
     "sink_cluster_cols": {
@@ -211,21 +267,21 @@
       "label": null,
       "name": "sink_cluster_cols",
       "options": {
-       "validationRegex": null,
-       "widgetDisplayType": "Text"
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
+      "widgetType": "text",
       "defaultValue": "",
       "label": null,
       "name": "sink_cluster_cols",
       "options": {
+       "widgetType": "text",
        "autoCreated": true,
-       "validationRegex": null,
-       "widgetType": "text"
-      },
-      "widgetType": "text"
+       "validationRegex": null
+      }
      }
     },
     "src_catalog": {
@@ -237,21 +293,21 @@
       "label": "",
       "name": "src_catalog",
       "options": {
-       "validationRegex": null,
-       "widgetDisplayType": "Text"
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
+      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "src_catalog",
       "options": {
+       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null,
-       "widgetType": "text"
-      },
-      "widgetType": "text"
+       "validationRegex": null
+      }
      }
     },
     "src_schema": {
@@ -263,21 +319,21 @@
       "label": "",
       "name": "src_schema",
       "options": {
-       "validationRegex": null,
-       "widgetDisplayType": "Text"
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
+      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "src_schema",
       "options": {
+       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null,
-       "widgetType": "text"
-      },
-      "widgetType": "text"
+       "validationRegex": null
+      }
      }
     },
     "src_table": {
@@ -289,21 +345,21 @@
       "label": "",
       "name": "src_table",
       "options": {
-       "validationRegex": null,
-       "widgetDisplayType": "Text"
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
+      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "src_table",
       "options": {
+       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null,
-       "widgetType": "text"
-      },
-      "widgetType": "text"
+       "validationRegex": null
+      }
      }
     },
     "tgt_catalog": {
@@ -315,21 +371,21 @@
       "label": "",
       "name": "tgt_catalog",
       "options": {
-       "validationRegex": null,
-       "widgetDisplayType": "Text"
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
+      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "tgt_catalog",
       "options": {
+       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null,
-       "widgetType": "text"
-      },
-      "widgetType": "text"
+       "validationRegex": null
+      }
      }
     },
     "tgt_schema": {
@@ -341,21 +397,21 @@
       "label": "",
       "name": "tgt_schema",
       "options": {
-       "validationRegex": null,
-       "widgetDisplayType": "Text"
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
+      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "tgt_schema",
       "options": {
+       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null,
-       "widgetType": "text"
-      },
-      "widgetType": "text"
+       "validationRegex": null
+      }
      }
     },
     "tgt_table": {
@@ -367,21 +423,21 @@
       "label": "",
       "name": "tgt_table",
       "options": {
-       "validationRegex": null,
-       "widgetDisplayType": "Text"
+       "widgetDisplayType": "Text",
+       "validationRegex": null
       },
       "parameterDataType": "String"
      },
      "widgetInfo": {
+      "widgetType": "text",
       "defaultValue": "",
       "label": "",
       "name": "tgt_table",
       "options": {
+       "widgetType": "text",
        "autoCreated": false,
-       "validationRegex": null,
-       "widgetType": "text"
-      },
-      "widgetType": "text"
+       "validationRegex": null
+      }
      }
     }
    }

--- a/src/lakefed_ingest/get_src_tbl_metadata.sql
+++ b/src/lakefed_ingest/get_src_tbl_metadata.sql
@@ -1,0 +1,12 @@
+-- Create view of source table in order to infer the schema
+-- Result of describe extended is returned to the job for use downstream
+declare or replace qry_str string;
+
+set var qry_str = 
+  "create or replace temp view vw_src as "
+  "select " || :select_list || " from " || :src_catalog || '.' || :src_schema || '.' || :src_table || " "  
+  "where 1 = 0";
+
+execute immediate qry_str;
+
+describe extended vw_src as json;


### PR DESCRIPTION
Updates to handle characters in source columns that are not allowed in Parquet, such as spaces.

- Enable [column mapping](https://docs.databricks.com/aws/en/delta/column-mapping) in target table, which allows for special characters as column names.
- Convert CTAS to create table statement, which is required for enabling column mapping at table creation.
- Get source table schema in a new job task, and pass it to the create_sink_table task as a parameter. This is necessary because `describe` doesn't return a result set that can be worked with programmatically. 

Other updates:

- Add truncation of target table prior to partitioned copy, as this is used for full copies. 
- Set fetchSize to 200000 in copy_data_incremental so it is consistent with other copy tasks
- Add select_list support to copy_data_partitioned